### PR TITLE
Add instructions to set nightly as the default tool chain

### DIFF
--- a/src/game-of-life/setup.md
+++ b/src/game-of-life/setup.md
@@ -26,6 +26,23 @@ rustup install nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 ```
 
+You may want to set your default tool chain to nightly:
+
+```
+rustup default nightly
+```
+
+This is convenient if you want to run tests, or have an editor that integrates with cargo. If you run `cargo build` on `stable` you will get this error:
+
+```
+error[E0554]: #![feature] may not be used on the stable release channel
+ --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.10/src/lib.rs:1:1
+  |
+1 | #![feature(proc_macro)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+```
+ 
+
 ### `npm`
 
 `npm` is a package manager for JavaScript. We will use it to install and run a

--- a/src/game-of-life/setup.md
+++ b/src/game-of-life/setup.md
@@ -26,14 +26,7 @@ rustup install nightly
 rustup target add wasm32-unknown-unknown --toolchain nightly
 ```
 
-You may want to set your default tool chain to nightly:
-
-```
-rustup default nightly
-```
-
-This is convenient if you want to run tests, or have an editor that integrates with cargo. If you run `cargo build` on `stable` you will get this error:
-
+If you run cargo and get this error:
 ```
 error[E0554]: #![feature] may not be used on the stable release channel
  --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-0.2.10/src/lib.rs:1:1
@@ -41,7 +34,13 @@ error[E0554]: #![feature] may not be used on the stable release channel
 1 | #![feature(proc_macro)]
   | ^^^^^^^^^^^^^^^^^^^^^^^
 ```
- 
+You may fix this by changing your default tool chain to `nightly` like this:
+
+```
+rustup default nightly
+```
+
+This is convenient if you want to run tests, or have an editor that integrates with cargo.
 
 ### `npm`
 


### PR DESCRIPTION
I stumbled a bit when I had the stable tool chain configured. It would have been useful to know that `cargo build` is supposed to work even if it is not strictly required to do the tutorial. So I thoght it was a good time to make my first contribution. I hope this is helpful.